### PR TITLE
クエリの内容によってフォームの内容を変えるようにする

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gaya-on-web",
-  "version": "0.1.0",
+  "version": "1.0.1",
   "private": true,
   "dependencies": {
     "@chakra-ui/icons": "^2.0.17",

--- a/src/RoomCreate/RoomCreate.js
+++ b/src/RoomCreate/RoomCreate.js
@@ -58,6 +58,12 @@ export const RoomCreate = props => {
             {/*<Button mb={1} ml={1} w={"20%"} colorScheme={"teal"} onClick={copyToClipboard(props.roomToken, this)}>コピー</Button>*/}
             <CopyForm text={props.roomToken} />
           </FormControl>
+          <FormControl mt={2}>
+            <FormLabel>招待 URL</FormLabel>
+            {/*<Input w={"78%"} value={props.roomToken} />*/}
+            {/*<Button mb={1} ml={1} w={"20%"} colorScheme={"teal"} onClick={copyToClipboard(props.roomToken, this)}>コピー</Button>*/}
+            <CopyForm text={window.location.protocol + '//' + window.location.host + "/?s=" + global.ServerUrl + "&t=" + props.roomToken} />
+          </FormControl>
         </Box>
         <Button colorScheme='teal' onClick={() => props.setWindowMode('start')}>Back</Button>
       </Box>

--- a/src/Start/Start.js
+++ b/src/Start/Start.js
@@ -20,6 +20,7 @@ function Form(props) {
 Form.propTypes = { children: PropTypes.node };
 export const Start = props => {
   const [error, setError] = React.useState(null);
+
   function joinRoom() {
     global.ServerUrl = document.getElementById('room-join-address-input').value;
     let token = document.getElementById('room-token-input').value;
@@ -105,6 +106,14 @@ export const Start = props => {
   }
 
   let serverUrl = global.ServerUrl;
+  let roomToken;
+  const urlParams = new URLSearchParams(window.location.search);
+  if (urlParams.has('s')) {
+    serverUrl = urlParams.get('s');
+  }
+  if (urlParams.has('t')) {
+    roomToken = urlParams.get('t');
+  }
 
   return (
     <Flex w={"100vw"} minH={"100vh"} alignItems={"center"} justifyContent={"center"} flexDirection={"column"}>
@@ -134,7 +143,8 @@ export const Start = props => {
           <Box textAlign={"center"}>
             <Input id={"room-join-address-input"} display={"block"} mb={1} w={"320px"} maxW={"80vw"} h={"40px"}
                    placeholder="サーバアドレス" defaultValue={serverUrl} />
-            <Input id={"room-token-input"} display={"block"} mb={1} w={"320px"} maxW={"80vw"} h={"40px"} placeholder="ルームトークン" />
+            <Input id={"room-token-input"} display={"block"} mb={1} w={"320px"} maxW={"80vw"} h={"40px"}
+                   placeholder="ルームトークン" defaultValue={roomToken} />
             <Button display={"block"} w={"320px"} maxW={"80vw"} h={"40px"} colorScheme='teal' onClick={() => joinRoom()}>Join</Button>
           </Box>
         </Flex>


### PR DESCRIPTION
## 概要
クエリの内容によって参加フォームの内容を変更し、
参加者とプレゼンターの間のやり取り、ストレスを減らす。

- s パラメータでルームホスト
  - https://example.com/?s=https://example.com
- t パラメータでルームトークン
  - https://example.com/?t=a1b2c3


## 変更点
- クエリの内容によって参加フォームの内容を変更した
- 作成ページで情報付きの URL をコピーできるように変更

## 関連Issue
https://github.com/isso-719/gaya-on-web/issues/1

## 動作確認
- クエリを変えてページ見てみる
<img width="525" alt="image" src="https://user-images.githubusercontent.com/39211268/224491233-dcb61453-9bf8-4c81-a46f-b2e3acc6d78b.png">
<img width="515" alt="image" src="https://user-images.githubusercontent.com/39211268/224491251-bb6c3b67-7b0f-4231-846f-b4ab23c111dd.png">
<img width="520" alt="image" src="https://user-images.githubusercontent.com/39211268/224491290-f11db6dc-64d1-4c96-9fb2-b4e94e43ca3c.png">

- 作成ページ
<img width="600" alt="image" src="https://user-images.githubusercontent.com/39211268/224491428-1a1e3c78-4e97-444a-a296-c3c504c83994.png">



## レビュワーに特にみてもらいたい点
特になし

## その他
特になし